### PR TITLE
DATAGO-79372: Add Publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,15 @@
 name: Release
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        type: choice
-        required: true
-        description: "Version bump type"
-        options:
-        - patch
-        - minor
-        - major
+  push:
+    # inputs:
+    #   version:
+    #     type: choice
+    #     required: true
+    #     description: "Version bump type"
+    #     options:
+    #     - patch
+    #     - minor
+    #     - major
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,15 @@
 name: Release
 on:
-  push:
-    # inputs:
-    #   version:
-    #     type: choice
-    #     required: true
-    #     description: "Version bump type"
-    #     options:
-    #     - patch
-    #     - minor
-    #     - major
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        required: true
+        description: "Version bump type"
+        options:
+        - patch
+        - minor
+        - major
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,13 +16,19 @@ jobs:
     name: Release
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    # environment: release
+    environment:
+      name: pypi
+      url: https://pypi.org/p/solace_ai_connector
+    permissions:
+       id-token: write
+       contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.COMMIT_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -49,16 +55,16 @@ jobs:
       - name: Build project for distribution
         run: hatch build
 
-      # - name: Publish package distributions to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
-      # - name: Create Release
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     artifacts: "dist/*.whl"
-      #     makeLatest: true
-      #     generateReleaseNotes: true
-      #     tag: ${{ env.CURRENT_VERSION }}
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*.whl"
+          makeLatest: true
+          generateReleaseNotes: true
+          tag: ${{ env.CURRENT_VERSION }}
 
       - name: Commit new version
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        required: true
+        description: "Version bump type"
+        options:
+        - patch
+        - minor
+        - major
+
+jobs:
+  release:
+    name: Release
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    # environment: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install hatch
+        run: |
+          pip install --upgrade pip
+          pip install hatch
+
+      - name: Bump Version
+        run: |
+          CURRENT_VERSION=$(hatch version)
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
+          hatch version "${{ github.event.inputs.version }}"
+          NEW_VERSION=$(hatch version)
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+
+      - name: Fail if the current version doesn't exist
+        if: env.CURRENT_VERSION == ''
+        run: exit 1
+
+      - name: Build project for distribution
+        run: hatch build
+
+      # - name: Publish package distributions to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+
+      # - name: Create Release
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     artifacts: "dist/*.whl"
+      #     makeLatest: true
+      #     generateReleaseNotes: true
+      #     tag: ${{ env.CURRENT_VERSION }}
+
+      - name: Commit new version
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -a -m "[ci skip] Bump version to $NEW_VERSION"
+          git push DATAGO-79372-publish-workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,4 +65,4 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -a -m "[ci skip] Bump version to $NEW_VERSION"
-          git push DATAGO-79372-publish-workflow
+          git push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solace_ai_connector"
-version = "0.0.1"
+dynamic = ["version"]
 authors = [
   { name="Edward Funnekotter", email="edward.funnekotter@solace.com" },
 ]
@@ -39,3 +39,6 @@ solace-ai-connector-gen-docs = "solace_ai_connector.tools.gen_component_docs:mai
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/solace_ai_connector"]
+
+[tool.hatch.version]
+path = "src/solace_ai_connector/__init__.py"


### PR DESCRIPTION
Adding the publish workflow. The workflow will be manually run and then:
* Build
* Upversion depending on the input (patch, minor, major)
* Create Github Release
* Publish to pypi

No keys are needed because of [PyPi's trusted publishing](https://docs.pypi.org/trusted-publishers/). All we have to do is add a deploy key on the SolaceLabs repository as well as configure the github environment