### PR TITLE
DATAGO-83398: Use PYPI token authentication

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,15 @@ permissions:
   checks: write
   contents: write
 
+env:
+  name: pypi
+
 jobs:
   release:
-    uses: SolaceDev/solace-public-workflows/.github/workflows/hatch_release_pypi.yml@v1.0.0
+    uses: SolaceDev/solace-public-workflows/.github/workflows/hatch_release_pypi.yml@v1.0.1
     with:
       version: ${{ github.event.inputs.version }}
       pypi-project: solace-ai-connector
     secrets:
       COMMIT_KEY: ${{ secrets.COMMIT_KEY }}
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
[DATAGO-83398](https://sol-jira.atlassian.net/browse/DATAGO-83398)
### What is the purpose of this change?

PYPI  currently does not allow trusted publishers for reusable workflows 
So we need to use PYPI API token to release using the action

### Anything reviews should focus on/be aware of?

See also 
[PR to solace-public-workflows](https://github.com/SolaceDev/solace-public-workflows/pull/3)

[DATAGO-83398]: https://sol-jira.atlassian.net/browse/DATAGO-83398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ