### PR TITLE
Add support for temporary queue with UUID queue name

### DIFF
--- a/src/solace_ai_connector/components/inputs_outputs/broker_base.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_base.py
@@ -11,6 +11,7 @@ from abc import abstractmethod
 from ..component_base import ComponentBase
 from ...common.message import Message
 from ...common.messaging.messaging_builder import MessagingServiceBuilder
+import uuid
 
 # TBD - at the moment, there is no connection sharing supported. It should be possible
 # to share a connection between multiple components and even flows. The changes
@@ -138,3 +139,6 @@ class BrokerBase(ComponentBase):
 
     def start(self):
         pass
+
+    def generate_uuid(self):
+        return str(uuid.uuid4())

--- a/src/solace_ai_connector/components/inputs_outputs/broker_input.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_input.py
@@ -38,13 +38,13 @@ info = {
         },
         {
             "name": "broker_queue_name",
-            "required": True,
-            "description": "Queue name for broker",
+            "required": False,
+            "description": "Queue name for broker, if not provided it will use a temporary queue",
         },
         {
             "name": "temporary_queue",
             "required": False,
-            "description": "Whether to create a temporary queue that will be deleted after disconnection",
+            "description": "Whether to create a temporary queue that will be deleted after disconnection, defaulted to True if broker_queue_name is not provided",
             "default": False,
         },
         {
@@ -91,7 +91,12 @@ class BrokerInput(BrokerBase):
         super().__init__(info, **kwargs)
         self.need_acknowledgement = True
         self.temporary_queue = self.get_config("temporary_queue", False)
-        self.broker_properties["temporary_queue"] = self.temporary_queue
+        # If broker_queue_name is not provided, use temporary queue
+        if not self.get_config("broker_queue_name"):
+            self.temporary_queue = True
+            self.broker_properties["temporary_queue"] = True
+            # Generating a UUID for the queue name
+            self.broker_properties["queue_name"] = self.generate_uuid()
         self.connect()
 
     def invoke(self, message, data):


### PR DESCRIPTION
This pull request adds support for a temporary queue with a UUID queue name. Previously, the code only supported a fixed queue name for the broker. Now, if a queue name is not provided, a temporary queue will be created with a randomly generated UUID as the queue name. This allows for more flexibility and avoids conflicts with existing queue names.