### PR TITLE
Update version dependencies for langchain and langchain-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
 ]
 dependencies = [
     "boto3~=1.34.122",
-    "langchain_core~=0.2.5",
-    "langchain~=0.2.3",
+    "langchain-core~=0.3.0",
+    "langchain~=0.3.0",
     "PyYAML~=6.0.1",
     "Requests~=2.32.3",
     "solace_pubsubplus>=1.8.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3~=1.34.122
-langchain_core~=0.2.5
-langchain~=0.2.3
+langchain-core~=0.3.0
+langchain~=0.3.0
 PyYAML~=6.0.1
 Requests~=2.32.3
 solace_pubsubplus~=1.8.0


### PR DESCRIPTION
This PR updates the version dependencies for `langchain` and `langchain-core` to ensure compatibility with the latest features and improvements. The versions have been incremented to `0.3.0` for both packages.