### PR TITLE
feat: AI-166: fix inconsistency with payload/data responses

### DIFF
--- a/src/solace_ai_connector/components/general/langchain/langchain_chat_model_with_history.py
+++ b/src/solace_ai_connector/components/general/langchain/langchain_chat_model_with_history.py
@@ -213,7 +213,7 @@ class LangChainChatModelWithHistory(LangChainChatModelBase):
                 True,
             )
 
-        result = namedtuple("Result", ["content", "uuid"])(
+        result = namedtuple("Result", ["content", "response_uuid"])(
             aggregate_result, response_uuid
         )
 
@@ -233,7 +233,7 @@ class LangChainChatModelWithHistory(LangChainChatModelBase):
         message = Message(
             payload={
                 "chunk": chunk,
-                "aggregate_result": aggregate_result,
+                "content": aggregate_result,
                 "response_uuid": response_uuid,
                 "first_chunk": first_chunk,
                 "last_chunk": last_chunk,

--- a/src/solace_ai_connector/components/general/openai/openai_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/openai/openai_chat_model_base.py
@@ -111,7 +111,7 @@ openai_info_base = {
                 "type": "string",
                 "description": "The current chunk of the response",
             },
-            "uuid": {
+            "response_uuid": {
                 "type": "string",
                 "description": "The UUID of the response",
             },
@@ -239,7 +239,7 @@ class OpenAIChatModelBase(ComponentBase):
             return {
                 "content": aggregate_result,
                 "chunk": current_batch,
-                "uuid": response_uuid,
+                "response_uuid": response_uuid,
                 "first_chunk": first_chunk,
                 "last_chunk": True,
                 "streaming": True,
@@ -255,7 +255,7 @@ class OpenAIChatModelBase(ComponentBase):
                 True,
             )
 
-        return {"content": aggregate_result, "uuid": response_uuid}
+        return {"content": aggregate_result, "response_uuid": response_uuid}
 
     def send_streaming_message(
         self,
@@ -269,7 +269,7 @@ class OpenAIChatModelBase(ComponentBase):
         message = Message(
             payload={
                 "chunk": chunk,
-                "aggregate_result": aggregate_result,
+                "content": aggregate_result,
                 "response_uuid": response_uuid,
                 "first_chunk": first_chunk,
                 "last_chunk": last_chunk,
@@ -290,7 +290,7 @@ class OpenAIChatModelBase(ComponentBase):
         message = Message(
             payload={
                 "chunk": chunk,
-                "aggregate_result": aggregate_result,
+                "content": aggregate_result,
                 "response_uuid": response_uuid,
                 "first_chunk": first_chunk,
                 "last_chunk": last_chunk,
@@ -299,9 +299,9 @@ class OpenAIChatModelBase(ComponentBase):
         )
 
         result = {
-            "aggregte_result": aggregate_result,
+            "content": aggregate_result,
             "chunk": chunk,
-            "uuid": response_uuid,
+            "response_uuid": response_uuid,
             "first_chunk": first_chunk,
             "last_chunk": last_chunk,
             "streaming": True,

--- a/src/solace_ai_connector/components/general/openai/openai_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/openai/openai_chat_model_base.py
@@ -106,7 +106,27 @@ openai_info_base = {
             "content": {
                 "type": "string",
                 "description": "The generated response from the model",
-            }
+            },
+            "chunk": {
+                "type": "string",
+                "description": "The current chunk of the response",
+            },
+            "uuid": {
+                "type": "string",
+                "description": "The UUID of the response",
+            },
+            "first_chunk": {
+                "type": "boolean",
+                "description": "Whether this is the first chunk of the response",
+            },
+            "last_chunk": {
+                "type": "boolean",
+                "description": "Whether this is the last chunk of the response",
+            },
+            "streaming": {
+                "type": "boolean",
+                "description": "Whether this is a streaming response",
+            },
         },
         "required": ["content"],
     },
@@ -279,7 +299,7 @@ class OpenAIChatModelBase(ComponentBase):
         )
 
         result = {
-            "content": aggregate_result,
+            "aggregte_result": aggregate_result,
             "chunk": chunk,
             "uuid": response_uuid,
             "first_chunk": first_chunk,

--- a/src/solace_ai_connector/components/general/openai/openai_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/openai/openai_chat_model_base.py
@@ -273,6 +273,7 @@ class OpenAIChatModelBase(ComponentBase):
                 "response_uuid": response_uuid,
                 "first_chunk": first_chunk,
                 "last_chunk": last_chunk,
+                "streaming": True,
             },
             user_properties=input_message.get_user_properties(),
         )
@@ -294,13 +295,14 @@ class OpenAIChatModelBase(ComponentBase):
                 "response_uuid": response_uuid,
                 "first_chunk": first_chunk,
                 "last_chunk": last_chunk,
+                "streaming": True,
             },
             user_properties=input_message.get_user_properties(),
         )
 
         result = {
-            "content": aggregate_result,
             "chunk": chunk,
+            "content": aggregate_result,
             "response_uuid": response_uuid,
             "first_chunk": first_chunk,
             "last_chunk": last_chunk,


### PR DESCRIPTION
Responses from the openai and langchain components were inconsistent with what data was placed in a message payload (for new streaming messages) and the data in the return from the invoke function. This led to problems in downstream components, some that used the payload data and some that used the previous component data.

This change may be non-backwards compatible, depending on how it was used.