### PR TITLE
AI-170: Add new broker type: dev_broker

### DIFF
--- a/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
+++ b/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
@@ -2,7 +2,6 @@
 messages to/from queues. It supports subscriptions based on topics."""
 
 from typing import Dict, List, Any
-import threading
 import queue
 import re
 from copy import deepcopy
@@ -10,12 +9,21 @@ from .messaging import Messaging
 
 
 class DevBroker(Messaging):
-    def __init__(self, broker_properties: dict):
+    def __init__(self, broker_properties: dict, flow_lock_manager, flow_kv_store):
         super().__init__(broker_properties)
-        self.subscriptions: Dict[str, List[str]] = {}
-        self.queues: Dict[str, queue.Queue] = {}
+        self.flow_lock_manager = flow_lock_manager
+        self.flow_kv_store = flow_kv_store
         self.connected = False
-        self.lock = threading.Lock()
+        self.subscriptions_lock = self.flow_lock_manager.get_lock("subscriptions")
+        with self.subscriptions_lock:
+            self.subscriptions = self.flow_kv_store.get("dev_broker:subscriptions")
+            if self.subscriptions is None:
+                self.subscriptions: Dict[str, List[str]] = {}
+                self.flow_kv_store.set("dev_broker:subscriptions", self.subscriptions)
+            self.queues = self.flow_kv_store.get("dev_broker:queues")
+            if self.queues is None:
+                self.queues: Dict[str, queue.Queue] = {}
+                self.flow_kv_store.set("dev_broker:queues", self.queues)
 
     def connect(self):
         self.connected = True
@@ -39,7 +47,11 @@ class DevBroker(Messaging):
             return None
 
     def send_message(
-        self, destination_name: str, payload: Any, user_properties: Dict = None
+        self,
+        destination_name: str,
+        payload: Any,
+        user_properties: Dict = None,
+        user_context: Dict = None,
     ):
         if not self.connected:
             raise RuntimeError("DevBroker is not connected")
@@ -56,25 +68,37 @@ class DevBroker(Messaging):
             # Clone the message for each queue to ensure isolation
             self.queues[queue_id].put(deepcopy(message))
 
+        if user_context and "callback" in user_context:
+            user_context["callback"](user_context)
+
     def subscribe(self, subscription: str, queue_id: str):
         if not self.connected:
             raise RuntimeError("DevBroker is not connected")
 
-        with self.lock:
+        subscription = self._subscription_to_regex(subscription)
+
+        with self.subscriptions_lock:
             if queue_id not in self.queues:
                 self.queues[queue_id] = queue.Queue()
             if subscription not in self.subscriptions:
                 self.subscriptions[subscription] = []
             self.subscriptions[subscription].append(queue_id)
 
+    def ack_message(self, message):
+        pass
+
     def _get_matching_queue_ids(self, topic: str) -> List[str]:
         matching_queue_ids = []
-        for subscription, queue_ids in self.subscriptions.items():
-            if self._topic_matches(subscription, topic):
-                matching_queue_ids.extend(queue_ids)
-        return list(set(matching_queue_ids))  # Remove duplicates
+        with self.subscriptions_lock:
+            for subscription, queue_ids in self.subscriptions.items():
+                if self._topic_matches(subscription, topic):
+                    matching_queue_ids.extend(queue_ids)
+            return list(set(matching_queue_ids))  # Remove duplicates
 
     @staticmethod
     def _topic_matches(subscription: str, topic: str) -> bool:
-        regex = subscription.replace(">", ".*").replace("*", "[^/]+")
-        return re.match(f"^{regex}$", topic) is not None
+        return re.match(f"^{subscription}$", topic) is not None
+
+    @staticmethod
+    def _subscription_to_regex(subscription: str) -> str:
+        return subscription.replace("*", "[^/]+").replace(">", ".*")

--- a/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
+++ b/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
@@ -1,0 +1,80 @@
+"""This is a simple broker for testing purposes. It allows sending and receiving 
+messages to/from queues. It supports subscriptions based on topics."""
+
+from typing import Dict, List, Any
+import threading
+import queue
+import re
+from copy import deepcopy
+from .messaging import Messaging
+
+
+class DevBroker(Messaging):
+    def __init__(self, broker_properties: dict):
+        super().__init__(broker_properties)
+        self.subscriptions: Dict[str, List[str]] = {}
+        self.queues: Dict[str, queue.Queue] = {}
+        self.connected = False
+        self.lock = threading.Lock()
+
+    def connect(self):
+        self.connected = True
+        queue_name = self.broker_properties.get("queue_name")
+        subscriptions = self.broker_properties.get("subscriptions", [])
+        if queue_name:
+            self.queues[queue_name] = queue.Queue()
+            for subscription in subscriptions:
+                self.subscribe(subscription["topic"], queue_name)
+
+    def disconnect(self):
+        self.connected = False
+
+    def receive_message(self, timeout_ms, queue_id: str):
+        if not self.connected:
+            raise RuntimeError("DevBroker is not connected")
+
+        try:
+            return self.queues[queue_id].get(timeout=timeout_ms / 1000)
+        except queue.Empty:
+            return None
+
+    def send_message(
+        self, destination_name: str, payload: Any, user_properties: Dict = None
+    ):
+        if not self.connected:
+            raise RuntimeError("DevBroker is not connected")
+
+        message = {
+            "payload": payload,
+            "topic": destination_name,
+            "user_properties": user_properties or {},
+        }
+
+        matching_queue_ids = self._get_matching_queue_ids(destination_name)
+
+        for queue_id in matching_queue_ids:
+            # Clone the message for each queue to ensure isolation
+            self.queues[queue_id].put(deepcopy(message))
+
+    def subscribe(self, subscription: str, queue_id: str):
+        if not self.connected:
+            raise RuntimeError("DevBroker is not connected")
+
+        with self.lock:
+            if queue_id not in self.queues:
+                self.queues[queue_id] = queue.Queue()
+            if subscription not in self.subscriptions:
+                self.subscriptions[subscription] = []
+            self.subscriptions[subscription].append(queue_id)
+
+    def _get_matching_queue_ids(self, topic: str) -> List[str]:
+        matching_queue_ids = []
+        for subscription, queue_ids in self.subscriptions.items():
+            if self._topic_matches(subscription, topic):
+                matching_queue_ids.extend(queue_ids)
+        return list(set(matching_queue_ids))  # Remove duplicates
+
+    @staticmethod
+    def _topic_matches(subscription: str, topic: str) -> bool:
+        regex = subscription.replace(">", ".*").replace("*", "[^/]+")
+        return re.match(f"^{regex}$", topic) is not None

--- a/src/solace_ai_connector/common/messaging/messaging.py
+++ b/src/solace_ai_connector/common/messaging/messaging.py
@@ -33,6 +33,12 @@ class DevBroker(Messaging):
 
     def connect(self):
         self.connected = True
+        queue_name = self.broker_properties.get("queue_name")
+        subscriptions = self.broker_properties.get("subscriptions", [])
+        if queue_name:
+            self.queues[queue_name] = queue.Queue()
+            for subscription in subscriptions:
+                self.subscribe(subscription["topic"], queue_name)
 
     def disconnect(self):
         self.connected = False

--- a/src/solace_ai_connector/common/messaging/messaging.py
+++ b/src/solace_ai_connector/common/messaging/messaging.py
@@ -1,8 +1,5 @@
-import threading
-import queue
-from typing import Dict, List, Any
-import re
-from copy import deepcopy
+from typing import Any, Dict
+
 
 class Messaging:
     def __init__(self, broker_properties: dict):
@@ -17,76 +14,10 @@ class Messaging:
     def receive_message(self, timeout_ms, queue_id: str):
         raise NotImplementedError
 
-    def send_message(self, destination_name: str, payload: Any, user_properties: Dict = None):
+    def send_message(
+        self, destination_name: str, payload: Any, user_properties: Dict = None
+    ):
         raise NotImplementedError
 
     def subscribe(self, subscription: str, queue_id: str):
         raise NotImplementedError
-
-class DevBroker(Messaging):
-    def __init__(self, broker_properties: dict):
-        super().__init__(broker_properties)
-        self.subscriptions: Dict[str, List[str]] = {}
-        self.queues: Dict[str, queue.Queue] = {}
-        self.connected = False
-        self.lock = threading.Lock()
-
-    def connect(self):
-        self.connected = True
-        queue_name = self.broker_properties.get("queue_name")
-        subscriptions = self.broker_properties.get("subscriptions", [])
-        if queue_name:
-            self.queues[queue_name] = queue.Queue()
-            for subscription in subscriptions:
-                self.subscribe(subscription["topic"], queue_name)
-
-    def disconnect(self):
-        self.connected = False
-
-    def receive_message(self, timeout_ms, queue_id: str):
-        if not self.connected:
-            raise RuntimeError("DevBroker is not connected")
-        
-        try:
-            return self.queues[queue_id].get(timeout=timeout_ms/1000)
-        except queue.Empty:
-            return None
-
-    def send_message(self, destination_name: str, payload: Any, user_properties: Dict = None):
-        if not self.connected:
-            raise RuntimeError("DevBroker is not connected")
-
-        message = {
-            'payload': payload,
-            'topic': destination_name,
-            'user_properties': user_properties or {}
-        }
-
-        matching_queue_ids = self._get_matching_queue_ids(destination_name)
-        
-        for queue_id in matching_queue_ids:
-            # Clone the message for each queue to ensure isolation
-            self.queues[queue_id].put(deepcopy(message))
-
-    def subscribe(self, subscription: str, queue_id: str):
-        if not self.connected:
-            raise RuntimeError("DevBroker is not connected")
-
-        with self.lock:
-            if queue_id not in self.queues:
-                self.queues[queue_id] = queue.Queue()
-            if subscription not in self.subscriptions:
-                self.subscriptions[subscription] = []
-            self.subscriptions[subscription].append(queue_id)
-
-    def _get_matching_queue_ids(self, topic: str) -> List[str]:
-        matching_queue_ids = []
-        for subscription, queue_ids in self.subscriptions.items():
-            if self._topic_matches(subscription, topic):
-                matching_queue_ids.extend(queue_ids)
-        return list(set(matching_queue_ids))  # Remove duplicates
-
-    @staticmethod
-    def _topic_matches(subscription: str, topic: str) -> bool:
-        regex = subscription.replace(">", ".*").replace("*", "[^/]+")
-        return re.match(f"^{regex}$", topic) is not None

--- a/src/solace_ai_connector/common/messaging/messaging.py
+++ b/src/solace_ai_connector/common/messaging/messaging.py
@@ -18,6 +18,3 @@ class Messaging:
         self, destination_name: str, payload: Any, user_properties: Dict = None
     ):
         raise NotImplementedError
-
-    def subscribe(self, subscription: str, queue_id: str):
-        raise NotImplementedError

--- a/src/solace_ai_connector/common/messaging/messaging.py
+++ b/src/solace_ai_connector/common/messaging/messaging.py
@@ -1,5 +1,8 @@
-# messaging.py - Base class for EDA messaging services
-
+import threading
+import queue
+from typing import Dict, List, Any
+import re
+from copy import deepcopy
 
 class Messaging:
     def __init__(self, broker_properties: dict):
@@ -11,14 +14,73 @@ class Messaging:
     def disconnect(self):
         raise NotImplementedError
 
-    def receive_message(self, timeout_ms):
+    def receive_message(self, timeout_ms, queue_id: str):
         raise NotImplementedError
 
-    # def is_connected(self):
-    #     raise NotImplementedError
+    def send_message(self, destination_name: str, payload: Any, user_properties: Dict = None):
+        raise NotImplementedError
 
-    # def send_message(self, destination_name: str, message: str):
-    #     raise NotImplementedError
+    def subscribe(self, subscription: str, queue_id: str):
+        raise NotImplementedError
 
-    # def subscribe(self, subscription: str, message_handler): #: MessageHandler):
-    #     raise NotImplementedError
+class DevBroker(Messaging):
+    def __init__(self, broker_properties: dict):
+        super().__init__(broker_properties)
+        self.subscriptions: Dict[str, List[str]] = {}
+        self.queues: Dict[str, queue.Queue] = {}
+        self.connected = False
+        self.lock = threading.Lock()
+
+    def connect(self):
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
+
+    def receive_message(self, timeout_ms, queue_id: str):
+        if not self.connected:
+            raise RuntimeError("DevBroker is not connected")
+        
+        try:
+            return self.queues[queue_id].get(timeout=timeout_ms/1000)
+        except queue.Empty:
+            return None
+
+    def send_message(self, destination_name: str, payload: Any, user_properties: Dict = None):
+        if not self.connected:
+            raise RuntimeError("DevBroker is not connected")
+
+        message = {
+            'payload': payload,
+            'topic': destination_name,
+            'user_properties': user_properties or {}
+        }
+
+        matching_queue_ids = self._get_matching_queue_ids(destination_name)
+        
+        for queue_id in matching_queue_ids:
+            # Clone the message for each queue to ensure isolation
+            self.queues[queue_id].put(deepcopy(message))
+
+    def subscribe(self, subscription: str, queue_id: str):
+        if not self.connected:
+            raise RuntimeError("DevBroker is not connected")
+
+        with self.lock:
+            if queue_id not in self.queues:
+                self.queues[queue_id] = queue.Queue()
+            if subscription not in self.subscriptions:
+                self.subscriptions[subscription] = []
+            self.subscriptions[subscription].append(queue_id)
+
+    def _get_matching_queue_ids(self, topic: str) -> List[str]:
+        matching_queue_ids = []
+        for subscription, queue_ids in self.subscriptions.items():
+            if self._topic_matches(subscription, topic):
+                matching_queue_ids.extend(queue_ids)
+        return list(set(matching_queue_ids))  # Remove duplicates
+
+    @staticmethod
+    def _topic_matches(subscription: str, topic: str) -> bool:
+        regex = subscription.replace(">", ".*").replace("*", "[^/]+")
+        return re.match(f"^{regex}$", topic) is not None

--- a/src/solace_ai_connector/common/messaging/messaging.py
+++ b/src/solace_ai_connector/common/messaging/messaging.py
@@ -15,6 +15,10 @@ class Messaging:
         raise NotImplementedError
 
     def send_message(
-        self, destination_name: str, payload: Any, user_properties: Dict = None
+        self,
+        destination_name: str,
+        payload: Any,
+        user_properties: Dict = None,
+        user_context: Dict = None,
     ):
         raise NotImplementedError

--- a/src/solace_ai_connector/common/messaging/messaging_builder.py
+++ b/src/solace_ai_connector/common/messaging/messaging_builder.py
@@ -1,6 +1,7 @@
 """Class to build a Messaging Service object"""
 
 from .solace_messaging import SolaceMessaging
+from .messaging import DevBroker
 
 
 # Make a Messaging Service builder - this is a factory for Messaging Service objects
@@ -15,6 +16,8 @@ class MessagingServiceBuilder:
     def build(self):
         if self.broker_properties["broker_type"] == "solace":
             return SolaceMessaging(self.broker_properties)
+        elif self.broker_properties["broker_type"] == "dev_broker":
+            return DevBroker(self.broker_properties)
 
         raise ValueError(
             f"Unsupported broker type: {self.broker_properties['broker_type']}"

--- a/src/solace_ai_connector/common/messaging/messaging_builder.py
+++ b/src/solace_ai_connector/common/messaging/messaging_builder.py
@@ -1,7 +1,7 @@
 """Class to build a Messaging Service object"""
 
 from .solace_messaging import SolaceMessaging
-from .messaging import DevBroker
+from .dev_broker_messaging import DevBroker
 
 
 # Make a Messaging Service builder - this is a factory for Messaging Service objects

--- a/src/solace_ai_connector/common/messaging/messaging_builder.py
+++ b/src/solace_ai_connector/common/messaging/messaging_builder.py
@@ -6,8 +6,10 @@ from .dev_broker_messaging import DevBroker
 
 # Make a Messaging Service builder - this is a factory for Messaging Service objects
 class MessagingServiceBuilder:
-    def __init__(self):
+    def __init__(self, flow_lock_manager, flow_kv_store):
         self.broker_properties = {}
+        self.flow_lock_manager = flow_lock_manager
+        self.flow_kv_store = flow_kv_store
 
     def from_properties(self, broker_properties: dict):
         self.broker_properties = broker_properties
@@ -17,7 +19,9 @@ class MessagingServiceBuilder:
         if self.broker_properties["broker_type"] == "solace":
             return SolaceMessaging(self.broker_properties)
         elif self.broker_properties["broker_type"] == "dev_broker":
-            return DevBroker(self.broker_properties)
+            return DevBroker(
+                self.broker_properties, self.flow_lock_manager, self.flow_kv_store
+            )
 
         raise ValueError(
             f"Unsupported broker type: {self.broker_properties['broker_type']}"

--- a/src/solace_ai_connector/common/messaging/solace_messaging.py
+++ b/src/solace_ai_connector/common/messaging/solace_messaging.py
@@ -246,8 +246,18 @@ class SolaceMessaging(Messaging):
             user_context=user_context,
         )
 
-    def receive_message(self, timeout_ms):
-        return self.persistent_receivers[0].receive_message(timeout_ms)
+    def receive_message(self, timeout_ms, queue_id):
+        broker_message = self.persistent_receivers[0].receive_message(timeout_ms)
+        if broker_message is None:
+            return None
+        
+        # Convert Solace message to dictionary format
+        return {
+            'payload': broker_message.get_payload_as_bytes(),
+            'topic': broker_message.get_destination_name(),
+            'user_properties': broker_message.get_properties(),
+            '_original_message': broker_message  # Keep original message for acknowledgement
+        }
 
     def subscribe(
         self, subscription: str, persistent_receiver: PersistentMessageReceiver
@@ -256,4 +266,7 @@ class SolaceMessaging(Messaging):
         persistent_receiver.add_subscription(sub)
 
     def ack_message(self, broker_message):
-        self.persistent_receiver.ack(broker_message)
+        if '_original_message' in broker_message:
+            self.persistent_receiver.ack(broker_message['_original_message'])
+        else:
+            log.warning("Cannot acknowledge message: original Solace message not found")

--- a/src/solace_ai_connector/common/messaging/solace_messaging.py
+++ b/src/solace_ai_connector/common/messaging/solace_messaging.py
@@ -250,13 +250,14 @@ class SolaceMessaging(Messaging):
         broker_message = self.persistent_receivers[0].receive_message(timeout_ms)
         if broker_message is None:
             return None
-        
+
         # Convert Solace message to dictionary format
         return {
-            'payload': broker_message.get_payload_as_bytes(),
-            'topic': broker_message.get_destination_name(),
-            'user_properties': broker_message.get_properties(),
-            '_original_message': broker_message  # Keep original message for acknowledgement
+            "payload": broker_message.get_payload_as_string()
+            or broker_message.get_payload_as_bytes(),
+            "topic": broker_message.get_destination_name(),
+            "user_properties": broker_message.get_properties(),
+            "_original_message": broker_message,  # Keep original message for acknowledgement
         }
 
     def subscribe(
@@ -266,7 +267,7 @@ class SolaceMessaging(Messaging):
         persistent_receiver.add_subscription(sub)
 
     def ack_message(self, broker_message):
-        if '_original_message' in broker_message:
-            self.persistent_receiver.ack(broker_message['_original_message'])
+        if "_original_message" in broker_message:
+            self.persistent_receiver.ack(broker_message["_original_message"])
         else:
             log.warning("Cannot acknowledge message: original Solace message not found")

--- a/src/solace_ai_connector/components/inputs_outputs/broker_base.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_base.py
@@ -33,6 +33,7 @@ class BrokerBase(ComponentBase):
     def __init__(self, module_info, **kwargs):
         super().__init__(module_info, **kwargs)
         self.broker_properties = self.get_broker_properties()
+        self.queue_id = self.generate_uuid()
         if self.broker_properties["broker_type"] not in ["test", "test_streaming"]:
             self.messaging_service = (
                 MessagingServiceBuilder()

--- a/src/solace_ai_connector/components/inputs_outputs/broker_base.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_base.py
@@ -33,7 +33,6 @@ class BrokerBase(ComponentBase):
     def __init__(self, module_info, **kwargs):
         super().__init__(module_info, **kwargs)
         self.broker_properties = self.get_broker_properties()
-        self.queue_id = self.generate_uuid()
         if self.broker_properties["broker_type"] not in ["test", "test_streaming"]:
             self.messaging_service = (
                 MessagingServiceBuilder(self.flow_lock_manager, self.flow_kv_store)

--- a/src/solace_ai_connector/components/inputs_outputs/broker_base.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_base.py
@@ -36,7 +36,7 @@ class BrokerBase(ComponentBase):
         self.queue_id = self.generate_uuid()
         if self.broker_properties["broker_type"] not in ["test", "test_streaming"]:
             self.messaging_service = (
-                MessagingServiceBuilder()
+                MessagingServiceBuilder(self.flow_lock_manager, self.flow_kv_store)
                 .from_properties(self.broker_properties)
                 .build()
             )

--- a/src/solace_ai_connector/components/inputs_outputs/broker_input.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_input.py
@@ -110,16 +110,18 @@ class BrokerInput(BrokerBase):
     def get_next_message(self, timeout_ms=None):
         if timeout_ms is None:
             timeout_ms = DEFAULT_TIMEOUT_MS
-        broker_message = self.messaging_service.receive_message(timeout_ms, self.broker_properties["queue_name"])
+        broker_message = self.messaging_service.receive_message(
+            timeout_ms, self.broker_properties["queue_name"]
+        )
         if not broker_message:
             return None
         self.current_broker_message = broker_message
 
-        payload = broker_message.get('payload')
+        payload = broker_message.get("payload")
         payload = self.decode_payload(payload)
 
-        topic = broker_message.get('topic')
-        user_properties = broker_message.get('user_properties', {})
+        topic = broker_message.get("topic")
+        user_properties = broker_message.get("user_properties", {})
         log.debug(
             "Received message from broker: topic=%s, user_properties=%s, payload length=%d",
             topic,

--- a/src/solace_ai_connector/components/inputs_outputs/broker_input.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_input.py
@@ -110,7 +110,7 @@ class BrokerInput(BrokerBase):
     def get_next_message(self, timeout_ms=None):
         if timeout_ms is None:
             timeout_ms = DEFAULT_TIMEOUT_MS
-        broker_message = self.messaging_service.receive_message(timeout_ms, self.queue_id)
+        broker_message = self.messaging_service.receive_message(timeout_ms, self.broker_properties["queue_name"])
         if not broker_message:
             return None
         self.current_broker_message = broker_message
@@ -127,12 +127,6 @@ class BrokerInput(BrokerBase):
             len(payload) if payload is not None else 0,
         )
         return Message(payload=payload, topic=topic, user_properties=user_properties)
-
-    def connect(self):
-        super().connect()
-        if self.broker_properties.get("broker_subscriptions"):
-            for subscription in self.broker_properties["broker_subscriptions"]:
-                self.messaging_service.subscribe(subscription["topic"], self.queue_id)
 
     def acknowledge_message(self, broker_message):
         self.messaging_service.ack_message(broker_message)

--- a/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
@@ -224,7 +224,9 @@ class BrokerRequestResponse(BrokerBase):
     def handle_responses(self):
         while not self.stop_signal.is_set():
             try:
-                broker_message = self.messaging_service.receive_message(1000)
+                broker_message = self.messaging_service.receive_message(
+                    1000, self.reply_queue_name
+                )
                 if broker_message:
                     self.process_response(broker_message)
             except Exception as e:
@@ -248,12 +250,10 @@ class BrokerRequestResponse(BrokerBase):
             topic = broker_message.get_topic()
             user_properties = broker_message.get_user_properties()
         else:
-            payload = broker_message.get_payload_as_string()
-            if payload is None:
-                payload = broker_message.get_payload_as_bytes()
+            payload = broker_message.get("payload")
             payload = self.decode_payload(payload)
-            topic = broker_message.get_destination_name()
-            user_properties = broker_message.get_properties()
+            topic = broker_message.get("topic")
+            user_properties = broker_message.get("user_properties", {})
 
         metadata_json = user_properties.get(
             "__solace_ai_connector_broker_request_reply_metadata__"

--- a/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
@@ -193,11 +193,12 @@ class BrokerRequestResponse(BrokerBase):
         ]
         self.test_mode = False
 
-        if self.broker_type == "solace":
-            self.connect()
-        elif self.broker_type == "test" or self.broker_type == "test_streaming":
+        if self.broker_type == "test" or self.broker_type == "test_streaming":
             self.test_mode = True
             self.setup_test_pass_through()
+        else:
+            self.connect()
+
         self.start()
 
     def start(self):


### PR DESCRIPTION
This change adds a 'dev_broker' broker_type that behaves like a Solace Broker, but just runs within the context of a single solace-ai-connector. As long as all flows are running within the same instance, then they can all use broker_type='dev_broker' and they will communicate like normal.

This should be fully backwards compatible.

Note - this was built on top of the websocket component changes, so the diff is against that branch.