### PR TITLE
AI-173: Support !include in yaml config files

### DIFF
--- a/src/solace_ai_connector/main.py
+++ b/src/solace_ai_connector/main.py
@@ -31,13 +31,17 @@ def process_includes(file_path, base_dir):
         content = f.read()
 
     def include_repl(match):
-        include_path = match.group(1).strip('\'"')
+        indent = match.group(1)  # Capture the leading spaces
+        include_path = match.group(2).strip('\'"')
         full_path = os.path.join(base_dir, include_path)
         if not os.path.exists(full_path):
             raise FileNotFoundError(f"Included file not found: {full_path}")
-        return process_includes(full_path, os.path.dirname(full_path))
+        included_content = process_includes(full_path, os.path.dirname(full_path))
+        # Indent each line of the included content
+        indented_content = '\n'.join(indent + line for line in included_content.splitlines())
+        return indented_content
 
-    include_pattern = re.compile(r'#include\s+(["\']?.+?["\']?)')
+    include_pattern = re.compile(r'^(\s*)#include\s+(["\']?.+?["\']?)', re.MULTILINE)
     return include_pattern.sub(include_repl, content)
 
 

--- a/src/solace_ai_connector/main.py
+++ b/src/solace_ai_connector/main.py
@@ -2,15 +2,18 @@ import os
 import sys
 import re
 import yaml
+from pathlib import Path
 from .solace_ai_connector import SolaceAiConnector
 
 
 def load_config(file):
     """Load configuration from a YAML file."""
     try:
-        # Load the YAML file as a string
-        with open(file, "r", encoding="utf8") as f:
-            yaml_str = f.read()
+        # Get the directory of the current file
+        file_dir = os.path.dirname(os.path.abspath(file))
+
+        # Load the YAML file as a string, processing includes
+        yaml_str = process_includes(file, file_dir)
 
         # Substitute the environment variables using os.environ
         yaml_str = expandvars_with_defaults(yaml_str)
@@ -21,6 +24,21 @@ def load_config(file):
     except Exception as e:  # pylint: disable=locally-disabled, broad-exception-caught
         print(f"Error loading configuration file: {e}", file=sys.stderr)
         sys.exit(1)
+
+def process_includes(file_path, base_dir):
+    """Process #include directives in the given file."""
+    with open(file_path, "r", encoding="utf8") as f:
+        content = f.read()
+
+    def include_repl(match):
+        include_path = match.group(1).strip('\'"')
+        full_path = os.path.join(base_dir, include_path)
+        if not os.path.exists(full_path):
+            raise FileNotFoundError(f"Included file not found: {full_path}")
+        return process_includes(full_path, os.path.dirname(full_path))
+
+    include_pattern = re.compile(r'#include\s+(["\']?.+?["\']?)')
+    return include_pattern.sub(include_repl, content)
 
 
 def expandvars_with_defaults(text):

--- a/src/solace_ai_connector/main.py
+++ b/src/solace_ai_connector/main.py
@@ -25,6 +25,7 @@ def load_config(file):
         print(f"Error loading configuration file: {e}", file=sys.stderr)
         sys.exit(1)
 
+
 def process_includes(file_path, base_dir):
     """Process #include directives in the given file."""
     with open(file_path, "r", encoding="utf8") as f:
@@ -32,16 +33,21 @@ def process_includes(file_path, base_dir):
 
     def include_repl(match):
         indent = match.group(1)  # Capture the leading spaces
-        include_path = match.group(2).strip('\'"')
+        indent = indent.replace("\n", "")  # Remove newlines
+        include_path = match.group(2).strip("'\"")
         full_path = os.path.join(base_dir, include_path)
         if not os.path.exists(full_path):
             raise FileNotFoundError(f"Included file not found: {full_path}")
         included_content = process_includes(full_path, os.path.dirname(full_path))
         # Indent each line of the included content
-        indented_content = '\n'.join(indent + line for line in included_content.splitlines())
+        indented_content = "\n".join(
+            indent + line for line in included_content.splitlines()
+        )
         return indented_content
 
-    include_pattern = re.compile(r'^(\s*)#include\s+(["\']?.+?["\']?)', re.MULTILINE)
+    include_pattern = re.compile(
+        r'^(\s*)!include\s+(["\']?[^"\s\']+)["\']?', re.MULTILINE
+    )
     return include_pattern.sub(include_repl, content)
 
 


### PR DESCRIPTION
This adds the ability to do:

```
!include my_stuff_at_root.yaml

my_obj:
  !include my_sub_object.yaml
```

This will copy the specified file (relative to current file) into the current file and do this recursively. If the !include directive is indented, then that amount of space will be added to each line of the inserted file.
