### PR TITLE
AI-354: Add configuration for broker-request-response for placing the reply topic in the message

### DIFF
--- a/src/solace_ai_connector/components/component_base.py
+++ b/src/solace_ai_connector/components/component_base.py
@@ -304,14 +304,9 @@ class ComponentBase:
             "request_expiry_ms": request_expiry_ms,
         }
 
-        if "response_topic_prefix" in self.broker_request_response_config:
-            rrc_config["response_topic_prefix"] = self.broker_request_response_config[
-                "response_topic_prefix"
-            ]
-        if "response_queue_prefix" in self.broker_request_response_config:
-            rrc_config["response_queue_prefix"] = self.broker_request_response_config[
-                "response_queue_prefix"
-            ]
+        for key in ["response_topic_prefix", "response_queue_prefix", "response_topic_insertion_expression"]:
+            if key in self.broker_request_response_config:
+                rrc_config[key] = self.broker_request_response_config[key]
 
         self.broker_request_response_controller = RequestResponseFlowController(
             config=rrc_config, connector=self.connector

--- a/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
@@ -6,14 +6,11 @@ import json
 import queue
 from copy import deepcopy
 
-# from typing import Dict, Any
-
 from ...common.log import log
 from .broker_base import BrokerBase
 from ...common.message import Message
 from ...common.utils import ensure_slash_on_end, ensure_slash_on_start
 
-# from ...common.event import Event, EventType
 
 info = {
     "class_name": "BrokerRequestResponse",
@@ -76,9 +73,15 @@ info = {
             "name": "response_topic_insertion_expression",
             "required": False,
             "description": (
-                "Expression to insert the reply topic into the request message. "
-                "If not set, the reply topic will only be added to the request_response_metadata."
-                ),
+                "Expression to insert the reply topic into the "
+                "request message. "
+                "If not set, the reply topic will only be added to the "
+                "request_response_metadata. The expression uses the "
+                "same format as other data expressions: "
+                "(e.g input.payload:myObj.replyTopic). "
+                "If there is no object type in the expression, "
+                "it will default to 'input.payload'."
+            ),
             "default": "",
         },
         {
@@ -166,6 +169,7 @@ info = {
 
 
 class BrokerRequestResponse(BrokerBase):
+    """Request-Response broker component for the Solace AI Event Connector"""
 
     def __init__(self, **kwargs):
         super().__init__(info, **kwargs)
@@ -188,9 +192,6 @@ class BrokerRequestResponse(BrokerBase):
         self.streaming_complete_expression = self.get_config(
             "streaming_complete_expression"
         )
-        self.response_topic_insertion_expression = self.get_config(
-            "response_topic_insertion_expression"
-        )
         self.broker_type = self.broker_properties.get("broker_type", "solace")
         self.broker_properties["temporary_queue"] = True
         self.broker_properties["queue_name"] = self.reply_queue_name
@@ -205,6 +206,15 @@ class BrokerRequestResponse(BrokerBase):
             },
         ]
         self.test_mode = False
+
+        self.response_topic_insertion_expression = self.get_config(
+            "response_topic_insertion_expression"
+        )
+        if self.response_topic_insertion_expression:
+            if ":" not in self.response_topic_insertion_expression:
+                self.response_topic_insertion_expression = (
+                    f"input.payload:{self.response_topic_insertion_expression}"
+                )
 
         if self.broker_type == "test" or self.broker_type == "test_streaming":
             self.test_mode = True
@@ -268,6 +278,10 @@ class BrokerRequestResponse(BrokerBase):
             payload = self.decode_payload(payload)
             topic = broker_message.get("topic")
             user_properties = broker_message.get("user_properties", {})
+
+        if not user_properties:
+            log.error("Received response without user properties: %s", payload)
+            return
 
         streaming_complete_expression = None
         metadata_json = user_properties.get(
@@ -416,7 +430,7 @@ class BrokerRequestResponse(BrokerBase):
                 self.response_topic_insertion_expression, self.response_topic
             )
             data["payload"] = tmp_message.get_payload()
-            data["user_properties"] = tmp_message.get_user_properties()            
+            data["user_properties"] = tmp_message.get_user_properties()
 
         if self.test_mode:
             if self.broker_type == "test_streaming":


### PR DESCRIPTION
With this change, you can add a configuration to agents to control if and where the reply topic should be placed in the request