### PR TITLE
The error_queue's depth should be configurable and errors discarded if full

### DIFF
--- a/examples/error_handler.yaml
+++ b/examples/error_handler.yaml
@@ -10,6 +10,8 @@
 # }
 # If value is not a number, the error will be caught, logged to file and send back to the Solace broker.
 # 
+# Subscribe to `ai_connector_error/*/*/*` to see the error messages.
+#
 # required ENV variables:
 # - SOLACE_BROKER_URL
 # - SOLACE_BROKER_USERNAME
@@ -38,6 +40,7 @@ flows:
       - component_name: error_input
         component_module: error_input
         component_config:
+          max_queue_depth: 100
       - component_name: error_logger
         component_module: file_output
         input_transforms:


### PR DESCRIPTION
**What is the purpose of this change?**
The solace-ai-connector has a concept of an error queue. This queue is drained by the ‘error_input’ component and then the errors can be processed however you like within a flow. The cognitive-mesh uses this to monitor for and capture errors in the system.

At the moment, the error_queue is on by default and does not have a configurable max depth for the queue. Also, if an error happens and the component_base tries to enqueue to that queue and it is full, then it will just block, waiting for the queue to empty. 
We need to make these changes:
Add the configuration to be able to set the max queue depth
If the error_queue is full, then just discard the error message instead of blocking on the queue

**How is this accomplished?**
Updated the Error_input component to drop the new messages when the error queue is full.

**Anything reviews should focus on/be aware of?**
The error queue is configured during the initialization of the SolaceAiConnector. This setup creates a queue and passes it to the components. However, the max-size parameter in the error_queue does not define the actual maximum size of the queue. Instead, the component, which acts as the queue’s entry point, determines when a message can be stored in the queue.