### PR TITLE
DATAGO-94939: Configure maximum redelivery message for the broker

### DIFF
--- a/examples/broker_input_output.yaml
+++ b/examples/broker_input_output.yaml
@@ -31,6 +31,7 @@ shared_config:
       broker_vpn: ${SOLACE_BROKER_VPN}
       reconnection_strategy: forever_retry # options: forever_retry, parametrized_retry
       retry_interval: 1000 # in milliseconds
+      max_redelivery_count: 3 # number of redelivery attempts. Default is forever.
 
 
 flows:

--- a/examples/broker_input_output.yaml
+++ b/examples/broker_input_output.yaml
@@ -31,7 +31,7 @@ shared_config:
       broker_vpn: ${SOLACE_BROKER_VPN}
       reconnection_strategy: forever_retry # options: forever_retry, parametrized_retry
       retry_interval: 1000 # in milliseconds
-      max_redelivery_count: 3 # number of redelivery attempts. Default is forever.
+      max_redelivery_count: 3 # number of redelivery attempts.
 
 
 flows:

--- a/src/solace_ai_connector/common/messaging/solace_messaging.py
+++ b/src/solace_ai_connector/common/messaging/solace_messaging.py
@@ -371,12 +371,17 @@ class SolaceMessaging(Messaging):
                     self.broker_properties.get("queue_name"),
                     self.broker_properties.get("subscriptions"),
                     self.broker_properties.get("temporary_queue"),
+                    self.broker_properties.get("max_redelivery_count"),
                 )
         except KeyboardInterrupt:  # pylint: disable=broad-except
             raise KeyboardInterrupt
 
     def bind_to_queue(
-        self, queue_name: str, subscriptions: list = None, temporary: bool = False
+        self,
+        queue_name: str,
+        subscriptions: list = None,
+        temporary: bool = False,
+        max_redelivery_count: int = None,
     ):
         if subscriptions is None:
             subscriptions = []
@@ -398,6 +403,22 @@ class SolaceMessaging(Messaging):
                 )
                 .build(queue)
             )
+
+            # set maximum redelivery count for the queue
+            if max_redelivery_count:
+                try:
+                    end_point_props = {
+                        "ENDPOINT_MAXMSG_REDELIVERY": str(max_redelivery_count),
+                    }
+                    self.persistent_receiver._end_point_props = {
+                        **self.persistent_receiver._end_point_props,
+                        **end_point_props,
+                    }
+                except Exception as e:
+                    log.error(
+                        f"{self.error_prefix} Error setting max redelivery count: {str(e)}"
+                    )
+
             self.persistent_receiver.start()
 
             log.debug(

--- a/src/solace_ai_connector/common/messaging/solace_messaging.py
+++ b/src/solace_ai_connector/common/messaging/solace_messaging.py
@@ -405,7 +405,7 @@ class SolaceMessaging(Messaging):
             )
 
             # set maximum redelivery count for the queue
-            if max_redelivery_count:
+            if max_redelivery_count != None:
                 try:
                     end_point_props = {
                         "ENDPOINT_MAXMSG_REDELIVERY": str(max_redelivery_count),

--- a/src/solace_ai_connector/components/inputs_outputs/broker_base.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_base.py
@@ -159,6 +159,7 @@ class BrokerBase(ComponentBase):
             "retry_interval": self.get_config("retry_interval"),
             "retry_count": self.get_config("retry_count"),
             "retry_interval": self.get_config("retry_interval"),
+            "max_redelivery_count": self.get_config("max_redelivery_count"),
         }
         return broker_properties
 


### PR DESCRIPTION
### What is the purpose of this change?
Failed messages may stay in the queue forever. We need to set the maximum number of redelivering. If all retries fail, the message should be dropped.

### How is this accomplished?
Added _max_redelivery_count_ to the broker configuration and overwrote the broker default setting.

### Anything reviews should focus on/be aware of?
Nothing
