### PR TITLE
AI-484: Throw better error if model config is invalid 

### DIFF
--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
@@ -256,8 +256,8 @@ class LiteLLMBase(ComponentBase):
         """Validate the model config and throw a descriptive error if it's invalid."""
         for model in config:
             params = model.get('litellm_params', {})
-            if not all([params.get('model'), params.get('api_key'), params.get('api_base')]):
+            if not all([params.get('model'), params.get('api_key')]):
                 raise ValueError(
-                    f"Each model config must have model_name, api_key, and api_base defined and not be None.\n"
+                    f"Each model configuration requires both a model name and an API key, neither of which can be None.\n"
                     f"Received config: {model}"
                 )

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
@@ -155,6 +155,7 @@ class LiteLLMBase(ComponentBase):
             else:
                 allowed_fails_policy = AllowedFailsPolicy()
 
+            self.validate_model_config(self.load_balancer_config)
             self.router = litellm.Router(
                 model_list=self.load_balancer_config,
                 retry_policy=retry_policy,
@@ -250,3 +251,13 @@ class LiteLLMBase(ComponentBase):
 
     def get_metrics(self):
         return self.stats
+
+    def validate_model_config(self, config):
+        """Validate the model config and throw a descriptive error if it's invalid."""
+        for model in config:
+            params = model.get('litellm_params', {})
+            if not all([params.get('model'), params.get('api_key'), params.get('api_base')]):
+                raise ValueError(
+                    f"Each model config must have model, api_key, and api_base defined and not be None.\n"
+                    f"Received config: {model}"
+                )

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
@@ -258,6 +258,6 @@ class LiteLLMBase(ComponentBase):
             params = model.get('litellm_params', {})
             if not all([params.get('model'), params.get('api_key'), params.get('api_base')]):
                 raise ValueError(
-                    f"Each model config must have model, api_key, and api_base defined and not be None.\n"
+                    f"Each model config must have model_name, api_key, and api_base defined and not be None.\n"
                     f"Received config: {model}"
                 )


### PR DESCRIPTION
### What is the purpose of this change?
Currently the following error is thrown if model name, api key or base url is undefined. This is quite unintuitive for the user. Adding a validation step for the model config allows us to throw a more descriptive error.

`Error creating flows: Error initializing load balancer: unsupported operand type(s) for +=: 'NoneType' and 'str'
Error during Solace AI Event Connector startup: Error initializing load balancer: unsupported operand type(s) for +=: 'NoneType' and 'str'
Traceback: Traceback (most recent call last):
  File "/Users/edfunnekotter/demo-test/solace-agent-mesh-demos/.venv/lib/python3.10/site-packages/solace_ai_connector/components/general/llm/litellm/litellm_base.py", line 158, in init_load_balancer
    self.router = litellm.Router(
  File "/Users/edfunnekotter/demo-test/solace-agent-mesh-demos/.venv/lib/python3.10/site-packages/litellm/router.py", line 386, in __init__
    self.set_model_list(model_list)
  File "/Users/edfunnekotter/demo-test/solace-agent-mesh-demos/.venv/lib/python3.10/site-packages/litellm/router.py", line 3901, in set_model_list
    _id = self._generate_model_id(_model_name, _litellm_params)
  File "/Users/edfunnekotter/demo-test/solace-agent-mesh-demos/.venv/lib/python3.10/site-packages/litellm/router.py", line 3776, in _generate_model_id
    concat_str += k
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
`

New error looks like this:
`Error creating flows: Error initializing load balancer: Each model config must have model, api_key, and api_base defined and not be None.
Received config: {'model_name': None, 'litellm_params': {'model': None, 'api_key': 'sk-aTynY8egEJVxhenMnFBmEQ', 'api_base': 'https://lite-llm.mymaas.net/'}}
Error during Solace AI Event Connector startup: Error initializing load balancer: Each model config must have model, api_key, and api_base defined and not be None.
Received config: {'model_name': None, 'litellm_params': {'model': None, 'api_key': 'sk-aTynY8egEJVxhenMnFBmEQ', 'api_base': 'https://lite-llm.mymaas.net/'}}
Traceback: Traceback (most recent call last):
... continued same as before
`

### How is this accomplished?
Adding a validation step for the model config allows us to throw a more descriptive error.


### Anything reviews should focus on/be aware of?
