### PR TITLE
AI-308: Handle litellm errors

### DIFF
--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
@@ -109,6 +109,7 @@ litellm_chat_info_base["config_parameters"].extend(
 
 LITELLM_ERROR_MESSAGES = {
     "litellm.ContextWindowExceededError": "The input is too long for the model to process. Please reduce the input size.",
+    "Prompt is too long": "The input is too long for the model to process. Please reduce the input size.",
     "litellm.InternalServerError: AnthropicException - Overloaded": "The model is overloaded. Please try again later.",
     "litellm.exceptions.RateLimitError": "The model has reached its rate limit. Please try again later."
 }
@@ -190,7 +191,11 @@ class LiteLLMChatModelBase(LiteLLMBase):
             log.error("Error invoking LiteLLM: %s", error_str)
             for error_pattern, error_message in LITELLM_ERROR_MESSAGES.items():
                 if error_pattern in error_str:
-                    return {"content": error_message, "response_uuid": response_uuid}
+                    return {
+                        "content": error_message,
+                        "response_uuid": response_uuid,
+                        "handle_error": True
+                    }
             raise e
         except Exception as e:
             log.error("Error invoking LiteLLM: %s", e)

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
@@ -136,6 +136,13 @@ class LiteLLMChatModelBase(LiteLLMBase):
         try:
             response = self.load_balance(messages, stream=False)
             return {"content": response.choices[0].message.content}
+        except APIConnectionError as e:
+            error_str = str(e)
+            log.error("Error invoking LiteLLM: %s", error_str)
+            return {
+                "content": error_str,
+                "handle_error": True
+            }
         except Exception as e:
             log.error("Error invoking LiteLLM: %s", e)
             raise e

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
@@ -191,12 +191,12 @@ class LiteLLMChatModelBase(LiteLLMBase):
             log.error("Error invoking LiteLLM: %s", error_str)
             for error_pattern, error_message in LITELLM_ERROR_MESSAGES.items():
                 if error_pattern in error_str:
-                    return {
-                        "content": error_message,
-                        "response_uuid": response_uuid,
-                        "handle_error": True
-                    }
-            raise e
+                    error_str = error_message
+            return {
+                "content": error_str,
+                "response_uuid": response_uuid,
+                "handle_error": True
+            }
         except Exception as e:
             log.error("Error invoking LiteLLM: %s", e)
             raise e

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
@@ -107,13 +107,6 @@ litellm_chat_info_base["config_parameters"].extend(
     ]
 )
 
-LITELLM_ERROR_MESSAGES = {
-    "litellm.ContextWindowExceededError": "The input is too long for the model to process. Please reduce the input size.",
-    "Prompt is too long": "The input is too long for the model to process. Please reduce the input size.",
-    "litellm.InternalServerError: AnthropicException - Overloaded": "The model is overloaded. Please try again later.",
-    "litellm.exceptions.RateLimitError": "The model has reached its rate limit. Please try again later."
-}
-
 class LiteLLMChatModelBase(LiteLLMBase):
 
     def __init__(self, info, **kwargs):
@@ -189,9 +182,6 @@ class LiteLLMChatModelBase(LiteLLMBase):
         except APIConnectionError as e:
             error_str = str(e)
             log.error("Error invoking LiteLLM: %s", error_str)
-            for error_pattern, error_message in LITELLM_ERROR_MESSAGES.items():
-                if error_pattern in error_str:
-                    error_str = error_message
             return {
                 "content": error_str,
                 "response_uuid": response_uuid,


### PR DESCRIPTION
### What is the purpose of this change?
Handling litellm errors (e.g. ContextWindowExceededError, InternalServerError, RateLimitError).
Prior to this change, litellm errors were not handled properly and would result in reinvoking the orchestrator until Timeout.

### How is this accomplished?
Catching any APIConnectionErrors and returning the error message to the orchestrator.

### Anything reviews should focus on/be aware of?
This is a multi-repository change, must be implemented after the SAM PR (AI-308).