### PR TITLE
AI-559: Orchestrator timeout errors & Gracefully exit on windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,7 @@ path = "src/solace_ai_connector/__init__.py"
 [tool.ruff]
 lint.select = ["E4", "E7", "E9", "F"]
 lint.ignore = ["F401", "E731"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pywin32 = {version = "^306", markers = "sys_platform == 'win32'"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "build~=1.2.2.post1",
     "pymongo~=4.10.1",
     "SQLAlchemy~=2.0.36",
+    'pywin32>=306; sys_platform == "win32"',
 ]
 
 [project.urls]
@@ -59,7 +60,3 @@ path = "src/solace_ai_connector/__init__.py"
 [tool.ruff]
 lint.select = ["E4", "E7", "E9", "F"]
 lint.ignore = ["F401", "E731"]
-
-[tool.poetry.dependencies]
-python = "^3.8"
-pywin32 = {version = "^306", markers = "sys_platform == 'win32'"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ Flask-SocketIO~=5.4.1
 build~=1.2.2.post1
 datadog~=0.50.2
 SQLAlchemy~=2.0.36
-pywin32~=306; sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Flask-SocketIO~=5.4.1
 build~=1.2.2.post1
 datadog~=0.50.2
 SQLAlchemy~=2.0.36
+pywin32~=306; sys_platform == 'win32'

--- a/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
@@ -424,6 +424,12 @@ class BrokerRequestResponse(BrokerBase):
             is_last = message.get_data(streaming_complete_expression)
             if not is_last:
                 last_piece = False
+                self.cache_service.add_data(
+                    key=request_id,
+                    value=cached_request,
+                    expiry=self.request_expiry_ms / 1000, # Reset expiry time
+                    component=self
+                )
 
         if last_piece:
             self.cache_service.remove_data(request_id)

--- a/src/solace_ai_connector/flow/request_response_flow_controller.py
+++ b/src/solace_ai_connector/flow/request_response_flow_controller.py
@@ -117,7 +117,6 @@ class RequestResponseFlowController:
                     if event.event_type == EventType.MESSAGE:
                         self.enqueue_time = time.time()
                         message = event.data
-                        print(f"\nmessage: {message.payload}")
                         last_message = message.get_data(streaming_complete_expression)
                         yield message, last_message
                         if last_message:

--- a/src/solace_ai_connector/flow/request_response_flow_controller.py
+++ b/src/solace_ai_connector/flow/request_response_flow_controller.py
@@ -108,9 +108,16 @@ class RequestResponseFlowController:
             # if this is the last message
             while True:
                 try:
+                    # Calculate remaining time based on the most recent enqueue_time
+                    now = time.time()
+                    elapsed_time = now - self.enqueue_time
+                    remaining_timeout = self.request_expiry_s - elapsed_time
+
                     event = self.response_queue.get(timeout=remaining_timeout)
                     if event.event_type == EventType.MESSAGE:
+                        self.enqueue_time = time.time()
                         message = event.data
+                        print(f"\nmessage: {message.payload}")
                         last_message = message.get_data(streaming_complete_expression)
                         yield message, last_message
                         if last_message:
@@ -122,10 +129,6 @@ class RequestResponseFlowController:
                         )
                 except Exception as e:
                     raise e
-
-                now = time.time()
-                elapsed_time = now - self.enqueue_time
-                remaining_timeout = self.request_expiry_s - elapsed_time
 
         # If we are not in streaming mode, we will return a single message
         # and then stop the iterator

--- a/src/solace_ai_connector/main.py
+++ b/src/solace_ai_connector/main.py
@@ -128,8 +128,14 @@ def main():
         elif signum == signal.SIGTERM:
             raise SystemExit("SIGTERM received")
 
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
+    if sys.platform == 'win32':
+        import win32api
+        def handler(type):
+            shutdown()
+        win32api.SetConsoleCtrlHandler(handler, True)
+    else:
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
 
     # Start the connector
     try:


### PR DESCRIPTION
### What is the purpose of this change?
~~Extend request time if the orchestrator is still streaming responses, but lower timeout limit if the orchestrator is not streaming back.~~
Continue streaming messages as long as the orchestrator receives messages.
Benefits: Permit longer requests while also catching orchestrator timeouts faster.
Windows users can now exit using `CTRL + C` from Powershell

### How is this accomplished?
~~New config `activity_timeout_s` that will raise a TimeoutError if the last activity time of a streamed response in more than its value.~~
Extend `remaining_timeout` value at each streamed messages received.

### Anything reviews should focus on/be aware of?
~~Will have to up the value `request_expiry_ms` in `orchestrator.yaml` file (possibly 300000). Could also add the new config `activity_timeout_s`.~~

I tried to handle TimeoutErrors differently, even though it could almost work flawlessly, it had lots of drawbacks. Reach out if interested.
