### PR TITLE
AI-644: Fix queue timeout issue when reading from request response queue.

### DIFF
--- a/src/solace_ai_connector/flow/request_response_flow_controller.py
+++ b/src/solace_ai_connector/flow/request_response_flow_controller.py
@@ -101,7 +101,7 @@ class RequestResponseFlowController:
         # Now we will wait for the response
         now = time.time()
         elapsed_time = now - self.enqueue_time
-        remaining_timeout = self.request_expiry_s - elapsed_time
+        remaining_timeout = max(0, self.request_expiry_s - elapsed_time)
         if stream:
             # If we are in streaming mode, we will return individual messages
             # until we receive the last message. Use the expression to determine
@@ -111,7 +111,7 @@ class RequestResponseFlowController:
                     # Calculate remaining time based on the most recent enqueue_time
                     now = time.time()
                     elapsed_time = now - self.enqueue_time
-                    remaining_timeout = self.request_expiry_s - elapsed_time
+                    remaining_timeout = max(0, self.request_expiry_s - elapsed_time)
 
                     event = self.response_queue.get(timeout=remaining_timeout)
                     if event.event_type == EventType.MESSAGE:


### PR DESCRIPTION
What is the purpose of this change?
To prevent potential issues with timeouts by ensuring the remaining timeout value is never set to zero or negative.

How is this accomplished?
The code now uses max(0, self.request_expiry_s - elapsed_time) when calculating the remaining timeout value, ensuring it always has a positive value when passed to queue operations.

In extremely rare timing conditions, the remaining timeout calculated to a negative value when reading from the llm response queue. This caused the queue read to fail, but left the llm response on the queue for the next request to read. This issue is not recoverable.

Anything reviews should focus on/be aware of?
Reviewers should verify that this fix properly handles the edge case where elapsed time equals or exceeds the request expiry time, and confirm that this change doesn't introduce any unexpected behavior in the request-response flow.