### PR TITLE
DATAGO-105467: Fix cleanup errors

### DIFF
--- a/src/solace_ai_connector/main.py
+++ b/src/solace_ai_connector/main.py
@@ -148,7 +148,7 @@ def main():
         sac.stop()
         sac.cleanup()
         print("Solace AI Connector exited successfully!")
-        sys.exit(0)
+        os._exit(0)
 
     def signal_handler(signum, frame):
         if signum == signal.SIGINT:

--- a/src/solace_ai_connector/solace_ai_connector.py
+++ b/src/solace_ai_connector/solace_ai_connector.py
@@ -311,8 +311,8 @@ class SolaceAiConnector:
         # Clean up queues
         for queue_name, q in self.flow_input_queues.items():
             try:
-                while not queue.empty():
-                    queue.get_nowait()
+                while not q.empty():
+                    q.get_nowait()
             except Exception as e:
                 log.error(f"Error cleaning queue {queue_name}", trace=e)
         self.flow_input_queues.clear()


### PR DESCRIPTION
🧩 Complexity Level: 🟢 Low

⏱️ Estimated Review Time: <5 minutes

### What is the purpose of this change?
Fix two errors when cleaning up solace ai connector:
- queue empty error
- thread lock error

### How is this accomplished?
- using proper queue names
- exiting application once solace ai connector is cleaned up without waiting on running threads

### Anything reviews should focus on/be aware of?
These were the running threads still active:
- solace.module.dispatcher_0 (Daemon: True)
- <unnamed>_AsyncOpsThread (Daemon: True)
- asyncio_0 (Daemon: True)
- Dummy-34 (Daemon: True)