### PR TITLE
DATAGO-106148: Make requests version more flexible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "PyYAML==6.0.2",
-    "Requests==2.32.4",
+    "Requests~=2.32.4",
     "solace_pubsubplus==1.9.0",
     "SQLAlchemy==2.0.40",
     'pywin32>=306; sys_platform == "win32"',


### PR DESCRIPTION
<!-- Example: 🟢 Low / 🟡 Medium / 🔴 High -->
🧩 Complexity Level: 🟢 Low

 <!-- Example: 5-10 minutes -->
⏱️ Estimated Review Time: 10–15 minutes

### What is the purpose of this change?
Make requests version more flexible so projects dependent on solace-ai-connector have fewer restrictions.

### How is this accomplished?
Changing strict requirement `==` to `~=` for the requeusts dependency.

### Anything reviews should focus on/be aware of?
No

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update requests dependency requirement to allow compatible versions rather than enforcing a specific version.
Main changes:
- Changed requests dependency from fixed version (==2.32.4) to compatible release specifier (~=2.32.4)

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
