### PR TITLE
DATAGO-107039: hotfix resolve package dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ openai = [
 # AWS integration (Bedrock, etc.)
 aws = [
     "boto3==1.39.0",
-    "langchain_aws==0.2.28",
+    "langchain_aws==0.2.19",
     "requests_aws4auth>=1.3.1",
 ]
 
@@ -279,7 +279,7 @@ all = [
     
     # From aws
     "boto3==1.39.0",
-    "langchain_aws==0.2.28",
+    "langchain_aws==0.2.19",
     "requests_aws4auth>=1.3.1",
     
     # From chromadb-vector-store


### PR DESCRIPTION
<!-- Example: 🟢 Low / 🟡 Medium / 🔴 High -->
🧩 Complexity Level: 🟢 Low

 <!-- Example: 1 minute -->
⏱️ Estimated Review Time: 1 minute

### What is the purpose of this change?
There is a package dependency issue that blocks micro integration builds.

### How is this accomplished?
Downgraded the langchain aws library version.

### Anything reviews should focus on/be aware of?

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Downgrade langchain_aws package from version 0.2.28 to 0.2.19 to resolve dependency conflicts.
Main changes:
- Reduced langchain_aws version from 0.2.28 to 0.2.19 in both aws dependency group and all dependencies list
- Re-added langchain_aws package that was missing from aws dependencies group

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
