### PR TITLE
fix(DATAGO-111857): improve error handling in SolaceMessaging by raising the original exception

### DIFF
--- a/src/solace_ai_connector/common/messaging/solace_messaging.py
+++ b/src/solace_ai_connector/common/messaging/solace_messaging.py
@@ -434,12 +434,12 @@ class SolaceMessaging(Messaging):
             )
 
         # Handle API exception
-        except PubSubPlusClientError:
+        except PubSubPlusClientError as e:
             log.warning(
                 f"{self.error_prefix} Error creating persistent receiver for queue [%s]",
-                queue_name,
+                queue_name
             )
-            raise exception
+            raise e
 
         # Add to list of receivers
         self.persistent_receivers.append(self.persistent_receiver)


### PR DESCRIPTION
## What is the purpose of this change?

Improve error handling in the SolaceMessaging component to ensure that the original exception is properly raised when creating a persistent receiver fails, making debugging and error handling more effective.

## How is this accomplished?

- fix: improve error handling in SolaceMessaging by raising the original exception
  - Capture the PubSubPlusClientError as variable 'e' instead of letting it pass uncaptured
  - Raise the actual exception 'e' instead of an undefined 'exception' variable

## Anything reviews should focus on/be aware of?

The fix addresses a bug where an undefined 'exception' variable was being raised, which would have caused a NameError rather than showing the actual underlying issue.